### PR TITLE
Refactor Color to class

### DIFF
--- a/stories/HeatGrid.tsx
+++ b/stories/HeatGrid.tsx
@@ -1,4 +1,4 @@
-import { Color, colorFromString, computeLinearGradientAtPos, stringFromColor } from '../utils/Color';
+import { Color } from '../utils/Color';
 
 interface HeatGridProps {
   data: Array<number>,
@@ -12,8 +12,8 @@ interface HeatGridProps {
 }
 
 export function HeatGrid(props: HeatGridProps) {
-  const colorMin: Color = colorFromString(props.colorMin);
-  const colorMax: Color = colorFromString(props.colorMax);
+  const colorMin: Color = Color.fromString(props.colorMin);
+  const colorMax: Color = Color.fromString(props.colorMax);
   const hasLabels = props.rowLabels !== undefined;
 
   return (
@@ -22,7 +22,7 @@ export function HeatGrid(props: HeatGridProps) {
         {props.rowLabels?.map(label => <p className="basis-full text-[16px] text-center">{label}</p>)}
       </div>
       <div className={`grid grow gap-[10px] grid-rows-${props.numRows} grid-cols-${props.numCols}`}>
-        {Array(props.numCols * props.numRows).fill(0).map((box, index) => <div style={{ backgroundColor: stringFromColor(computeLinearGradientAtPos(props.data[index], colorMin, colorMax))}}></div>)}
+        {Array(props.numCols * props.numRows).fill(0).map((box, index) => <div style={{ backgroundColor: Color.interpolateLinear(props.data[index], colorMin, colorMax).toString()}}></div>)}
       </div>
     </div>
   )

--- a/stories/HeatGrid.tsx
+++ b/stories/HeatGrid.tsx
@@ -4,8 +4,6 @@ interface HeatGridProps {
   data: Array<number>,
   colorMin: string,
   colorMax: string,
-  numCols: number,
-  numRows: number,
   rowLabels?: Array<string>
   width?: number,
   height?: number,
@@ -21,8 +19,8 @@ export function HeatGrid(props: HeatGridProps) {
       <div className="flex gap-[2px] flex-row justify-between">
         {props.rowLabels?.map(label => <p className="basis-full text-[16px] text-center">{label}</p>)}
       </div>
-      <div className={`grid grow gap-[10px] grid-rows-${props.numRows} grid-cols-${props.numCols}`}>
-        {Array(props.numCols * props.numRows).fill(0).map((box, index) => <div style={{ backgroundColor: Color.interpolateLinear(props.data[index], colorMin, colorMax).toString()}}></div>)}
+      <div className={`grid grow gap-[10px] grid-rows-5 grid-cols-7`}>
+        {Array(35).fill(0).map((box, index) => <div style={{ backgroundColor: Color.interpolateLinear(props.data[index], colorMin, colorMax).toString()}}></div>)}
       </div>
     </div>
   )

--- a/utils/Color.ts
+++ b/utils/Color.ts
@@ -22,9 +22,9 @@ export class Color {
     const cpos = Math.max(0, Math.min(1, pos));
     const ipos: number = 1 - cpos;
     return new Color(
-      col1.r * cpos + col2.r * ipos,
-      col1.g * cpos + col2.g * ipos,
-      col1.b * cpos + col2.b * ipos
+      col1.r * ipos + col2.r * cpos,
+      col1.g * ipos + col2.g * cpos,
+      col1.b * ipos + col2.b * cpos
     )
   }
 

--- a/utils/Color.ts
+++ b/utils/Color.ts
@@ -19,11 +19,12 @@ export class Color {
   }
   
   static interpolateLinear(pos: number, col1: Color, col2: Color): Color {
-    const ipos: number = 1 - pos;
+    const cpos = Math.max(0, Math.min(1, pos));
+    const ipos: number = 1 - cpos;
     return new Color(
-      col1.r * pos + col2.r * ipos,
-      col1.g * pos + col2.g * ipos,
-      col1.b * pos + col2.b * ipos
+      col1.r * cpos + col2.r * ipos,
+      col1.g * cpos + col2.g * ipos,
+      col1.b * cpos + col2.b * ipos
     )
   }
 

--- a/utils/Color.ts
+++ b/utils/Color.ts
@@ -1,29 +1,34 @@
-// TODO: Replace with a proper class
+export class Color {
 
-export interface Color {
-  r: number,
-  g: number,
+  r: number
+  g: number
   b: number
-}
 
-export function colorFromString(str: string): Color {
-  return {
-    r: Number('0x' + str.slice(1, 3)),
-    g: Number('0x' + str.slice(3, 5)),
-    b: Number('0x' + str.slice(5))
-  };
-}
+  constructor (r: number, g: number, b: number) {
+    this.r = Math.round(Math.max(0, Math.min(255, r)));
+    this.g = Math.round(Math.max(0, Math.min(255, g)));
+    this.b = Math.round(Math.max(0, Math.min(255, b)));
+  }
 
-export function stringFromColor(col: Color): string {
-  console.log(col);
-  return '#' + Math.round(col.r).toString(16).padStart(2, '0') + Math.round(col.g).toString(16).padStart(2, '0') + Math.round(col.b).toString(16).padStart(2, '0');
-}
+  static fromString(str: string): Color {
+    return new Color(
+      Number('0x' + str.slice(1, 3)),
+      Number('0x' + str.slice(3, 5)),
+      Number('0x' + str.slice(5))
+    );
+  }
+  
+  static interpolateLinear(pos: number, col1: Color, col2: Color): Color {
+    const ipos: number = 1 - pos;
+    return new Color(
+      col1.r * pos + col2.r * ipos,
+      col1.g * pos + col2.g * ipos,
+      col1.b * pos + col2.b * ipos
+    )
+  }
 
-export function computeLinearGradientAtPos(pos: number, col1: Color, col2: Color): Color {
-  const ipos: number = 1 - pos;
-  return {
-    r: col1.r * pos + col2.r * ipos,
-    g: col1.g * pos + col2.g * ipos,
-    b: col1.b * pos + col2.b * ipos
-  };
+  toString(): string {
+    return '#' + Math.round(this.r).toString(16).padStart(2, '0') + Math.round(this.g).toString(16).padStart(2, '0') + Math.round(this.b).toString(16).padStart(2, '0');
+  }
+
 }

--- a/utils/Color.ts
+++ b/utils/Color.ts
@@ -22,9 +22,9 @@ export class Color {
     const cpos = Math.max(0, Math.min(1, pos));
     const ipos: number = 1 - cpos;
     return new Color(
-      col1.r * ipos + col2.r * cpos,
-      col1.g * ipos + col2.g * cpos,
-      col1.b * ipos + col2.b * cpos
+      col1.r * cpos + col2.r * ipos,
+      col1.g * cpos + col2.g * ipos,
+      col1.b * cpos + col2.b * ipos
     )
   }
 


### PR DESCRIPTION
It was bugging me, and now it's not.

<!--
ELLIPSIS_HIDDEN
-->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 87315f9f77934b620777aeb50b5365a72d6c7787  | 
|--------|--------|

### Summary:
Refactored color handling into a `Color` class with methods for creation, interpolation, and conversion, and updated `HeatGrid` to use this new class, including a correction to the interpolation formula.

**Key points**:
- Introduced `Color` class in `utils/Color.ts`
- Added methods: `constructor`, `fromString`, `interpolateLinear`, `toString`
- Updated `HeatGrid` in `stories/HeatGrid.tsx` to use `Color` class
- Corrected interpolation formula in `interpolateLinear` method
- Removed old color handling functions


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!--
ELLIPSIS_HIDDEN
-->
